### PR TITLE
Adding name/description/license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
+  "name": "spotweb/spotweb",
+  "description": "A decentralized usenet community based on the Spotnet protocol.",
   "type": "project",
+  "license": "MIT",
   "require": {
     "mobiledetect/mobiledetectlib": "~2.5.2",
     "jean-damien/pchart": "~2.1.3",


### PR DESCRIPTION
I have to revoke my statement about name and description not being part of a project.
It seems that packagist/composer are supporting the installation projects through composer.

What you need for this are tags on the project (which they don't have yet but I guess you can also use a branch like dev-master (not sure)). And in the composer file a name, description (optional?), type and license (optional?).

I found this information here and tested this with a symfony project.

Source:
https://getcomposer.org/doc/03-cli.md#create-project
https://getcomposer.org/doc/04-schema.md#type

Sorry for this, but at least I fixed it for you :grin:
We're all keep learning :smile: 