### PR TITLE
Updated NNTP package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,9 @@
     "boxcar/boxcar": "dev-master",
     "uskr/nma-php": "~0.0.2",
     "notifo/notifo-php": "~1.0.0",
-    "gdwebs/nntp": "~1.0.0",
+    "gdwebs/nntp": "^1.2.0",
     "php": ">=5.3.0"
   },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/GeoffreyDijkstra/NNTP"
-    }
-  ],
   "require-dev": {
     "phpunit/phpunit": "~4.8.0"
   },


### PR DESCRIPTION
Removed custom repository location, because package is now available at packagist, also changed version to latest release. (see new releases of [gdwebs\NNTP](https://github.com/GeoffreyDijkstra/NNTP/releases) package)